### PR TITLE
Enable rbenv in spacemacs

### DIFF
--- a/spacemacs
+++ b/spacemacs
@@ -44,6 +44,9 @@
      markdown
      shell-script
      )
+
+   ruby-version-manager 'rbenv
+
    ;; A list of packages and/or extensions that will not be install and loaded.
    dotspacemacs-excluded-packages '()
    ;; If non-nil spacemacs will delete any orphan packages, i.e. packages that


### PR DESCRIPTION
In case if you are using `rbenv` ruby package manager it could bring you possibility to run `rspec` tests inside spacemacs using `ruby-test-run` command.
